### PR TITLE
adapt to newer rspec

### DIFF
--- a/spec/minimization_unidimensional_spec.rb
+++ b/spec/minimization_unidimensional_spec.rb
@@ -14,10 +14,10 @@ describe Minimization::Unidimensional, "subclass" do
       @min.iterate
     end
     it "#x_minimum be close to expected" do 
-      @min.x_minimum.should be_close(@p1,@min.epsilon)
+      @min.x_minimum.should be_within(@min.epsilon).of(@p1)
     end
     it "#f_minimum ( f(x)) be close to expected" do 
-      @min.f_minimum.should be_close(@p2,@min.epsilon)
+      @min.f_minimum.should be_within(@min.epsilon).of(@p2)
     end
     context "#log" do
       subject {@min.log}
@@ -32,10 +32,10 @@ describe Minimization::Unidimensional, "subclass" do
       @min = Minimization::GoldenSection.minimize(-1000,1000, &@func)
     end
     it "#x_minimum be close to expected" do 
-      @min.x_minimum.should be_close(@p1,@min.epsilon)
+      @min.x_minimum.should be_within(@min.epsilon).of(@p1)
     end
     it "#f_minimum ( f(x)) be close to expected" do 
-      @min.f_minimum.should be_close(@p2,@min.epsilon)
+      @min.f_minimum.should be_within(@min.epsilon).of(@p2)
     end
     context "#log" do
       subject {@min.log}
@@ -48,10 +48,10 @@ describe Minimization::Unidimensional, "subclass" do
       @min = Minimization::Brent.minimize(-1000,1000, &@func)
     end
     it "should x be correct" do 
-      @min.x_minimum.should be_close(@p1,@min.epsilon)
+      @min.x_minimum.should be_within(@min.epsilon).of(@p1)
     end
     it "should f(x) be correct" do 
-      @min.f_minimum.should be_close(@p2,@min.epsilon)
+      @min.f_minimum.should be_within(@min.epsilon).of(@p2)
     end
     context "#log" do
       subject {@min.log}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'minimization.rb'
-require 'spec'
-require 'spec/autorun'
+require 'rspec'
+require 'rspec/autorun'
 
-Spec::Runner.configure do |config|
+RSpec.configure do |config|
   
 end
 


### PR DESCRIPTION
hi,

I noticed that files in spec/ use the syntax of old versions of RSpec. Please find here a proposition to update them to a newer version of RSpec2:
- use 'rspec' instead of 'spec'
- use be_within instead of be_close.

Thanks!

Cheers,

Cédric
