### PR TITLE
Removed some redundancies from the Nelder-Mead algorithm

### DIFF
--- a/lib/multidim/nelder_mead.rb
+++ b/lib/multidim/nelder_mead.rb
@@ -119,9 +119,7 @@ module Minimization
         vertex_i = @start_configuration[i]
         0.upto(i) do |j|
           raise "equals vertices #{j} and #{j+1} in simplex configuration" if steps[j] == 0.0
-          0.upto(j) do |k|
-            vertex_i[k] = steps[k]
-          end
+          vertex_i[j] = steps[j]
         end
       end
     end
@@ -203,9 +201,8 @@ module Minimization
     def iterate
       # set previous simplex as the current simplex
       @previous = Array.new(@simplex.length)
-      0.upto(@simplex.length - 1) do |i|
-        point = @simplex[i].point                                # clone require?
-        @previous[i] = PointValuePair.new(point, f(point))
+      @simplex.each_with_index do |v,i| 
+        @previous[i] = PointValuePair.new(v.point, v.value)
       end
       # iterate simplex
       iterate_simplex


### PR DESCRIPTION
I have fixed some redundancies in the code, which I have discovered while adapting the method for usage in my [mixed_models](https://github.com/agisga/mixed_models) gem.
1. I have removed an unnecessary for-loop in `#start_configuration`
2. I have removed unnecessary evaluations of the objective function `f` in `#iterate`. Namely, when `@previous` gets assigned the vertices of `@simplex`, the values at the vertices are already known either from a previous run of `#iterate_simplex` or from `#initialize` (if it's the first iteration). In my use case in `mixed_models`, this made the mixed linear model fitting algorithm twice as fast.
